### PR TITLE
Big legs clip mask fixes

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -1246,6 +1246,7 @@
 	fullness_icons = 3
 	ani_state = "bigleggy_stanced"
 	extra_overlay_w = "bigleggy_markings_stanced"
+	clip_mask_state = null
 
 /datum/sprite_accessory/tail/taur/bigleggy/canine
 	name = "Big Leggies (Canine Tail)"


### PR DESCRIPTION


## About The Pull Request
Removes the taur clip mask from the big legs sprites

## Why it's good for the game 
Let anthros use anthro clothes for crying out loud

## Changelog

:cl: Arrhythmia_V
qol: No more clip mask for big leggies. Fat ass furries can now actually wear their clothes without them being abruptly cut off in a very revealing spot.
/:cl:
