### PR TITLE
ERT Borg Edits

### DIFF
--- a/code/modules/mob/living/silicon/robot/sprites/event/combat.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/event/combat.dm
@@ -73,7 +73,7 @@
 */
 
 /datum/robot_sprite/dogborg/combat/smolraptor
-	sprite_icon = 'icons/mob/robot/smallraptors/smolraptor_syndie.dmi'
+	sprite_icon = 'icons/mob/robot/smallraptors/smolraptor_ninja.dmi' //Chaosstation change - no syndicate combat sprites
 	name = "Small Raptor"
 	sprite_icon_state = "smolraptor"
 	has_eye_light_sprites = TRUE
@@ -132,6 +132,7 @@
 	sprite_hud_icon_state = "ert"
 	rest_sprite_options = list("Default")
 
+/* //Chaosstation change - Not suitable for ERT
 /datum/robot_sprite/dogborg/tall/combat/borgi
 	name = "Borgi"
 	sprite_icon_state = "borgi"
@@ -139,6 +140,7 @@
 	rest_sprite_options = list("Default")
 	has_eye_sprites = FALSE
 	has_eye_light_sprites = TRUE
+*/
 
 /datum/robot_sprite/dogborg/tall/combat/raptor
 	name = "Raptor V-4"
@@ -175,21 +177,21 @@
 
 /datum/robot_sprite/dogborg/tall/combat/tall/mmeka
 	name = "NIKO"
-	sprite_icon_state = "mmekasyndi"
+	sprite_icon_state = "mmekaninja"
 	has_vore_belly_sprites = TRUE
 	icon_x = 32
 	pixel_x = 0
 
 /datum/robot_sprite/dogborg/tall/combat/tall/fmeka
 	name = "NIKA"
-	sprite_icon_state = "fmekasyndi"
+	sprite_icon_state = "fmekaninja"
 	has_vore_belly_sprites = TRUE
 	icon_x = 32
 	pixel_x = 0
 
 /datum/robot_sprite/dogborg/tall/combat/tall/k4t
 	name = "K4T"
-	sprite_icon_state = "k4tsyndi"
+	sprite_icon_state = "k4tninja"
 	has_vore_belly_sprites = FALSE
 	icon_x = 32
 	pixel_x = 0

--- a/code/modules/mob/living/silicon/robot/sprites/event/combat.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/event/combat.dm
@@ -168,7 +168,7 @@
 
 /datum/robot_sprite/dogborg/tall/combat/tall
 	name = "MEKA"
-	sprite_icon_state = "mekasyndi"
+	sprite_icon_state = "mekaninja"
 	module_type = "Combat"
 	sprite_icon = 'icons/mob/robot/tallrobot/tallrobots.dmi'
 	has_vore_belly_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/subtypes/exploration/exploration-sprites.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/exploration/exploration-sprites.dm
@@ -36,6 +36,7 @@
 	icon_x = 32
 	pixel_x = 0
 
+/* // This is better suited for an ERT borg sprite
 /datum/robot_sprite/dogborg/explorer/smolraptor
 	sprite_icon = 'icons/mob/robot/smallraptors/smolraptor_ninja.dmi'
 	name = "Small Raptor"
@@ -44,7 +45,7 @@
 	has_vore_belly_sprites = TRUE
 	has_dead_sprite_overlay = FALSE
 	rest_sprite_options = list("Default", "Sit", "Bellyup")
-
+*/
 /* placeholder
 /datum/robot_sprite/dogborg/tall/explorer
 	module_type = "Exploration"


### PR DESCRIPTION
See PR CL



## About The Pull Request

Replaces ERT borg syndicate sprites with ninja sprites. This is to keep with ERT borg design and not confuse ERT synthetics with hostiles and cause friendly fire incidents.

## Changelog

:cl: Arrhythmia_V
qol: ERT Borg sprites no longer use syndicate designs
/:cl:


