### PR TITLE
Paramedic undersuit selector now has default suits

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -536,6 +536,8 @@
 /datum/gear/uniform/paramedic_selector/New()
 	..()
 	var/list/selector_uniforms = list(
+		"Trauma Team"=/obj/item/clothing/under/rank/medical/paramedic,
+		"EMT"=/obj/item/clothing/under/rank/medical/paramedic_alt,
 		"dark"=/obj/item/clothing/under/rank/paramedunidark,
 		"dark w/ skirt"=/obj/item/clothing/under/rank/parameduniskirtdark,
 		"light"=/obj/item/clothing/under/rank/paramedunilight,


### PR DESCRIPTION
Another thing that I don't understand how this wasnt already implemented

:cl: Arrhythmia_V
add: Paramedic undersuit selector in the loadout now has default options
/:cl:

