### PR TITLE
Give Paramedic a Taser

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -113,6 +113,7 @@
 	belt = /obj/item/storage/belt/medical/emt
 	pda_slot = slot_l_store
 	id_type = /obj/item/card/id/medical/emt
+	backpack_contents = /obj/item/gun/energy/taser //Chaosstation addition
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 
 /decl/hierarchy/outfit/job/medical/paramedic/emt

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -113,7 +113,7 @@
 	belt = /obj/item/storage/belt/medical/emt
 	pda_slot = slot_l_store
 	id_type = /obj/item/card/id/medical/emt
-	backpack_contents = /obj/item/gun/energy/taser //Chaosstation addition
+	back = /obj/item/gun/energy/taser //Chaosstation addition
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 
 /decl/hierarchy/outfit/job/medical/paramedic/emt

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -124,7 +124,8 @@
 		/obj/item/storage/box/freezer,
 		/obj/item/clothing/accessory/storage/white_vest,
 		/obj/item/taperoll/medical,
-		/obj/item/gun/energy/taser) //Chaosstation addition
+		/obj/item/gun/energy/taser,
+		/obj/item/clothing/accessory/holster/leg/black) //Chaosstation addition
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -123,7 +123,8 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/storage/box/freezer,
 		/obj/item/clothing/accessory/storage/white_vest,
-		/obj/item/taperoll/medical)
+		/obj/item/taperoll/medical,
+		/obj/item/gun/energy/taser) //Chaosstation addition
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -77,7 +77,7 @@
 	display_name = "holster selection"
 	description = "Select from a number of general-purpose handgun holsters, or a baton lanyard."
 	path = /obj/item/clothing/accessory/holster
-	allowed_roles = list(JOB_SITE_MANAGER, JOB_HEAD_OF_PERSONNEL, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY,JOB_DETECTIVE,JOB_TALON_CAPTAIN,JOB_TALON_GUARD,JOB_BLUESHIELD_GUARD,JOB_SECURITY_PILOT) //YW ADDITIONS
+	allowed_roles = list(JOB_SITE_MANAGER, JOB_HEAD_OF_PERSONNEL, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY,JOB_DETECTIVE,JOB_PARAMEDIC,JOB_TALON_CAPTAIN,JOB_TALON_GUARD,JOB_BLUESHIELD_GUARD,JOB_SECURITY_PILOT) //YW ADDITIONS //Chaosstation addition - Paramedic
 
 /datum/gear/accessory/holster/New()
 	..()


### PR DESCRIPTION
## About The Pull Request

This has been a thing I have wanted to add for years now. Inspired by the RP restricted but mechanics permitted use of guns by paramedics on CEV Eris, I felt it could be implemented here.

## Changelog

:cl: Arrhythmia_V
add: Nanotrasen security has now authorized Paramedics to carry firearms. You can find them in their lockers. A taser during code green or a lethal weapon on code red. NT Security would like to remind medical staff that these guns should only be handled by paramedics or doctors acting in that capacity, NOT EMTs. The Vir medical board would also like to remind medics that medical staff is only allowed to use guns to defend themselves or their patients, and using a weapon in aggression is an ethics violation and will lead to an investigation and possible suspension of license to practice. 
add: To support this new change, Paramedics are allowed to choose a gun holster in the loadout menu
admin: CENTCOM will be watching medics closely to make sure they are not abusing their gun privileges
/:cl:


